### PR TITLE
feat: add empty states to pages #29

### DIFF
--- a/client/src/pages/EmployerApplicants.jsx
+++ b/client/src/pages/EmployerApplicants.jsx
@@ -94,7 +94,8 @@ export default function EmployerApplicants() {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-200">
-              {applicants.map((app) => (
+              {applicants.length>0 ?(
+              applicants.map((app) => (
                 <tr
                   key={app._id}
                   className="hover:bg-gray-50 transition duration-150"
@@ -136,7 +137,16 @@ export default function EmployerApplicants() {
                     </Link>
                   </td>
                 </tr>
-              ))}
+              ))
+            ) :(
+              <tr>
+                <td colSpan="5">
+                    <div className="p-12 text-center text-gray-400">
+                      No applicants yet for this job.
+                    </div>
+                  </td>
+              </tr>
+              )}
             </tbody>
           </table>
           <div className="p-4 bg-gray-50 border-t border-gray-200 text-center">

--- a/client/src/pages/StudentDashboard.jsx
+++ b/client/src/pages/StudentDashboard.jsx
@@ -98,7 +98,8 @@ export default function StudentDashboard() {
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
-                {recentApplications.map((app) => (
+                {recentApplications.length>0 ?(
+                recentApplications.map((app) => (
                   <tr key={app._id} className="hover:bg-gray-50 transition-colors">
                     <td className="px-6 py-4 font-semibold text-[#008BDC]">{app.job_id.title}</td>
                     <td className="px-6 py-4 text-gray-700 font-medium">{app.job_id.company}</td>
@@ -109,7 +110,16 @@ export default function StudentDashboard() {
                       </span>
                     </td>
                   </tr>
-                ))}
+                ))
+              ) : (
+              <tr>
+                <td colSpan="4">
+                      <div className="p-12 text-center text-gray-400">
+                        No applications found.
+                      </div>
+                    </td>
+              </tr>
+              )}
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
Added empty state messages to key dashboard tables to improve user feedback when no data is present.

Key Changes
Employer View: Added "No applicants yet for this job" message to the applicants table.

Student View: Added "No applications found" message to the recent applications table.

Styling: Used centered gray text with p-12 padding as per requirements.

Closes #29